### PR TITLE
Fix for bug resulting from top-level class redefinition

### DIFF
--- a/lib/seed_dump/perform.rb
+++ b/lib/seed_dump/perform.rb
@@ -42,8 +42,16 @@ module SeedDump
         f =~ /models\/(.*).rb/
         # split path by /, camelize the constituents, and then reform as a formal class name
         parts = $1.split("/").map {|x| x.camelize}
+
         # Initialize nested model namespaces
-        parts.clip.inject(Object) { |x, y| x.const_set(y, Module.new) }
+        parts.clip.inject(Object) do |x, y|
+          if x.const_defined?(y)
+            x.const_get(y)
+          else
+            x.const_set(y, Module.new)
+          end
+        end
+
         model = parts.join("::")
         require f
 


### PR DESCRIPTION
I was seeing a bug that resulted from my `User` class being skipped for not inheriting from `ActiveRecord::Base`:

```
Skipping non-ActiveRecord model User...
```

However, `User` does in fact inherit from `ActiveRecord::Base`. I tracked it down to User being redefined as a module during class loading. I added some logic to avoid such redefinition.
