### PR TITLE
Handle abstract_class setting in ActiveRecord.

### DIFF
--- a/lib/seed_dump/perform.rb
+++ b/lib/seed_dump/perform.rb
@@ -125,7 +125,7 @@ module SeedDump
       @seed_rb = ""
       @models.sort.each do |model|
           m = model.constantize
-          if m.ancestors.include?(ActiveRecord::Base)
+          if m.ancestors.include?(ActiveRecord::Base) && !m.abstract_class
             puts "Adding #{model} seeds." if @opts['verbose']
 
             if @opts['skip_callbacks']

--- a/test/models/abstract_sample.rb
+++ b/test/models/abstract_sample.rb
@@ -1,0 +1,3 @@
+class AbstractSample < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/test/models/child_sample.rb
+++ b/test/models/child_sample.rb
@@ -1,0 +1,4 @@
+class ChildSample < AbstractSample
+  attr_accessible :name
+end
+

--- a/test/seed_dump_test.rb
+++ b/test/seed_dump_test.rb
@@ -18,14 +18,14 @@ class SeedDumpTest < ActiveSupport::TestCase
     @env['MODEL_DIR'] = 'test/models/*.rb'
     @sd.setup @env 
     @sd.loadModels
-    assert_equal ["Sample"], @sd.models
+    assert_equal ["AbstractSample", "ChildSample", "Sample"], @sd.models
   end
 
   test "support nested models" do
     @env['MODEL_DIR'] = 'test/models/**/*.rb'
     @sd.setup @env 
     @sd.loadModels
-    assert_equal ["Nested::Sample", "Sample"], @sd.models
+    assert_equal ["AbstractSample", "ChildSample", "Nested::Sample", "Sample"], @sd.models
   end
 
   test "without timestamps" do
@@ -53,6 +53,16 @@ class SeedDumpTest < ActiveSupport::TestCase
     @sd.loadModels
     @sd.dumpModels
     assert @sd.last_record.include?("id"), "WITH_ID must include id"
+  end
+
+  test "skip abstract model" do
+    @env['MODELS'] = "AbstractSample"
+    @env['MODEL_DIR'] = 'test/models/*.rb'
+    @env['TIMESTAMPS'] = false
+    @sd.setup @env
+    @sd.loadModels
+    @sd.dumpModels
+    assert_equal [], @sd.last_record
   end
 
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,13 @@ require 'active_record'
 ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
 
 ActiveRecord::Schema.define(:version => 1) do
- create_table "samples", :force => true do |t|
+  create_table "child_samples", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "samples", :force => true do |t|
     t.string   "string"
     t.text     "text"
     t.integer  "integer"


### PR DESCRIPTION
Currently when a class that inherits from ActiveRecord::Base sets "self.abstract_class = true", that means there is not a related table for the class. It is intended to be inherited by other models that do have a related table.

https://github.com/rails/rails/blob/v3.2.13/activerecord/lib/active_record/inheritance.rb#L46

Just wrote the test (and necessary changes to other tests) and made the fix.

Craig
