### PR TITLE
Sort only if id is excluded

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -98,7 +98,9 @@ class SeedDump
         end
       end
 
-      @models.sort! { |a, b| a.to_s <=> b.to_s }
+      if @opts['exclude'].include? 'id'
+        @models.sort! { |a, b| a.to_s <=> b.to_s }
+      end
 
       @models.each do |model|
         puts "Adding #{model} seeds." if @opts['verbose']


### PR DESCRIPTION
Sorting the models if the id is included should be disabled because of foreign key constraints. Another way would be to disable foreign key checks in this case.
