### PR TITLE
clarified exclude usage and RailsEngine Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Options are common to both the Rake task and the console, except where noted.
 
 `batch_size`: Controls the number of records that are written to file at a given time.  Default: 1000.  If you're running out of memory when dumping, try decreasing this.  If things are dumping too slow, trying increasing this.
 
-`exclude`: Attributes to be excluded from the dump.  Default: `id, created_at, updated_at`.
+`exclude`: Attributes to be excluded from the dump.  Default: `id, created_at, updated_at`. If you need to include these columns pass "EXCLUDE=" as empty and the columns will be included
 
 `file`: Write to the specified output file.  Default in Rake task is `db/seeds.rb`.  Console returns the dump as a string by default.
 
 `limit`: Dump no more then this amount of data.  Default: no limit.  Rake task only.  In the console just pass in an ActiveRecord::Relation with the appropriate limit (e.g. `SeedDump.dump(User.limit(5))`).
 
-`model[s]`: Restrict the dump to the specified comma-separated list of models.  Default: all models.  Rake task only.
+`model[s]`: Restrict the dump to the specified comma-separated list of models.  Default: all models.  If you are using a Rails engine you can dump a specific model by passing "EngineName::ModelName". Rake task only.
 


### PR DESCRIPTION
I've added some text in the readme regarding 2 things.
1.  How to dump with primary keys. It looks like the old "WITH_ID" option has been replaced with EXCLUDE . 
2.  You've made changes in the past to support Rails Engines. I added a quick bit about using Rails Engine in the MODELS section.

We are using this gem to sync product data from production back to development. Keeping the primary keys and using Engine's models are needful !
