### PR TITLE
Make tests able to run with most recent ActiveRecord version

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -22,6 +22,10 @@ class Rails
       @already_called = true
     end
   end
+
+  def self.env
+    'test'
+  end
 end
 
 module Helpers


### PR DESCRIPTION
Fixes the following:
(...)/activerecord-4.1.4/lib/active_record/connection_handling.rb:3:in `block in module:ConnectionHandling': undefined method `env' for Rails:Class (NoMethodError)
