### PR TITLE
Add SKIP_VALIDATIONS for rails3 branch

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -95,6 +95,9 @@ TIMESTAMPS:
 SKIP_CALLBACKS:
  Deactivate callbacks while importing.
 
+SKIP_VALIDATIONS:
+ Deactivate validations while importing.
+
 PG_SCHEMA:
  Postgres schema support
 

--- a/lib/seed_dump/perform.rb
+++ b/lib/seed_dump/perform.rb
@@ -24,6 +24,7 @@ module SeedDump
       @opts['no-data'] = env['NO_DATA'].true?
       @opts['without_protection'] = env['WITHOUT_PROTECTION'].true? || (env['WITHOUT_PROTECTION'].nil? && @opts['timestamps'])
       @opts['skip_callbacks'] = env['SKIP_CALLBACKS'].true?
+      @opts['skip_validations'] = env['SKIP_VALIDATIONS'].true?
       @opts['models']  = env['MODELS'] || (env['MODEL'] ? env['MODEL'] : "")
       @opts['file']    = env['FILE'] || "#{Rails.root}/db/seeds.rb"
       @opts['append']  = (env['APPEND'].true? && File.exists?(@opts['file']) )
@@ -133,6 +134,11 @@ module SeedDump
               @seed_rb << "#{model}.reset_callbacks :save\n"
               @seed_rb << "#{model}.reset_callbacks :create\n"
               puts "Callbacks are disabled." if @opts['verbose']
+            end
+
+            if @opts['skip_validations']
+              @seed_rb << "#{model}.reset_callbacks :validate\n"
+              puts "Validations are disabled." if @opts['verbose']
             end
 
             @seed_rb << dumpModel(m) << "\n\n"


### PR DESCRIPTION
I made this patch against v0.5.3, since I needed it in Rails 3, but it might work for Rails 4 too.

Add a SKIP_VALIDATIONS config option that adds 'Model.reset_callbacks :validate' code in seeds.rb. I needed this to import my data.