### PR TITLE
support for HashWithIndifferentAccess field

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -42,6 +42,8 @@ class SeedDump
                 value.to_s(:db)
               when Range
                 range_to_string(value)
+              when ActiveSupport::HashWithIndifferentAccess
+                return "#{value.to_s}.with_indifferent_access"
               else
                 value
               end


### PR DESCRIPTION
If model had  `serialize :field, HashWithIndifferentAccess`
it was returned as a Hash, thus breaking model creation from seed dump