### PR TITLE
fix: uninitialized constant SeedDump::DumpMethods::IPAddr.

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 class SeedDump
   module DumpMethods
     include Enumeration


### PR DESCRIPTION
$> rake

FFFFF.F.FFFFFFFF.............

Failures:

  1) SeedDump.dump activerecord-import should dump in the activerecord-import format when import is true
     Failure/Error: SeedDump.dump(Sample, import: true, exclude: []).should eq <<-RUBY
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:132:in `block (4 levels) in <top (required)>'

  2) SeedDump.dump activerecord-import should omit excluded columns if they are specified
     Failure/Error: SeedDump.dump(Sample, import: true, exclude: [:id, :created_at, :updated_at]).should eq <<-RUBY
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:142:in `block (4 levels) in <top (required)>'

  3) SeedDump.dump with a batch_size parameter should not raise an exception
     Failure/Error: SeedDump.dump(Sample, batch_size: 100)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:94:in `block (4 levels) in <top (required)>'

  4) SeedDump.dump with a batch_size parameter should not cause records to not be dumped
     Failure/Error: SeedDump.dump(Sample, batch_size: 2).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:98:in `block (4 levels) in <top (required)>'

  5) SeedDump.dump Array should return the dump of the models passed in
     Failure/Error: SeedDump.dump(Sample.all.to_a, batch_size: 2).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:43:in`block in enumerable_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:42:in `each'
     # ./lib/seed_dump/dump_methods/enumeration.rb:42:in`each_with_index'
     # ./lib/seed_dump/dump_methods/enumeration.rb:42:in `enumerable_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in`write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in `dump'
     # ./spec/dump_methods_spec.rb:106:in`block (4 levels) in <top (required)>'

  6) SeedDump.dump without file option should return the dump of the models passed in
     Failure/Error: SeedDump.dump(Sample).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:27:in `block (4 levels) in <top (required)>'

  7) SeedDump.dump ActiveRecord relation with an order parameter should dump the models in the specified order
     Failure/Error: SeedDump.dump(Sample.order('integer DESC')).should eq("Sample.create!([\n  {string: \"string\", text: \"text\", integer: 2, float: 3.14, decimal: \"2.72\", datetime: \"1776-07-04 19:14:00\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false},\n  {string: \"string\", text: \"text\", integer: 1, float: 3.14, decimal: \"2.72\", datetime: \"1776-07-04 19:14:00\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false},\n  {string: \"string\", text: \"text\", integer: 0, float: 3.14, decimal: \"2.72\", datetime: \"1776-07-04 19:14:00\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false}\n])\n")
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:66:in `block (5 levels) in <top (required)>'

  8) SeedDump.dump ActiveRecord relation with a limit parameter should dump the number of models specified by the limit when the limit is smaller than the batch size
     Failure/Error: SeedDump.dump(Sample.limit(1)).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:80:in `block (5 levels) in <top (required)>'

  9) SeedDump.dump ActiveRecord relation with a limit parameter should dump the number of models specified by the limit when the limit is larger than the batch size but not a multiple of the batch size
     Failure/Error: SeedDump.dump(Sample.limit(3), batch_size: 2).should eq(expected_output(false, 3))
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:87:in `block (5 levels) in <top (required)>'

  10) SeedDump.dump ActiveRecord relation without an order parameter should dump the models sorted by primary key ascending
     Failure/Error: SeedDump.dump(Sample).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:72:in `block (5 levels) in <top (required)>'

  11) SeedDump.dump Range should dump a class with ranges
     Failure/Error: SeedDump.dump([RangeSample.new]).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:43:in`block in enumerable_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:42:in `each'
     # ./lib/seed_dump/dump_methods/enumeration.rb:42:in`each_with_index'
     # ./lib/seed_dump/dump_methods/enumeration.rb:42:in `enumerable_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in`write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in `dump'
     # ./spec/dump_methods_spec.rb:126:in`block (4 levels) in <top (required)>'

  12) SeedDump.dump with an exclude parameter should exclude the specified attributes from the dump
     Failure/Error: SeedDump.dump(Sample, exclude: [:id, :created_at, :updated_at, :string, :float, :datetime]).should eq(expected_output)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:118:in `block (4 levels) in <top (required)>'

  13) SeedDump.dump with file option should dump the models to the specified file
     Failure/Error: SeedDump.dump(Sample, file: @filename)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:41:in `block (4 levels) in <top (required)>'

  14) SeedDump.dump with file option with append option should append to the file rather than overwriting it
     Failure/Error: SeedDump.dump(Sample, file: @filename)
     NameError:
       uninitialized constant SeedDump::DumpMethods::IPAddr
     # ./lib/seed_dump/dump_methods.rb:39:in `value_to_s'
     # ./lib/seed_dump/dump_methods.rb:34:in`dump_attribute_new'
     # ./lib/seed_dump/dump_methods.rb:25:in `block in dump_record'
     # ./lib/seed_dump/dump_methods.rb:24:in`each'
     # ./lib/seed_dump/dump_methods.rb:24:in `dump_record'
     # ./lib/seed_dump/dump_methods/enumeration.rb:28:in`block (2 levels) in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:27:in `block in active_record_enumeration'
     # ./lib/seed_dump/dump_methods/enumeration.rb:14:in`active_record_enumeration'
     # ./lib/seed_dump/dump_methods.rb:84:in `write_records_to_io'
     # ./lib/seed_dump/dump_methods.rb:10:in`dump'
     # ./spec/dump_methods_spec.rb:48:in `block (5 levels) in <top (required)>'

3 deprecation warnings total

Finished in 0.26474 seconds (files took 0.75126 seconds to load)
29 examples, 14 failures

Failed examples:

rspec ./spec/dump_methods_spec.rb:131 # SeedDump.dump activerecord-import should dump in the activerecord-import format when import is true
rspec ./spec/dump_methods_spec.rb:141 # SeedDump.dump activerecord-import should omit excluded columns if they are specified
rspec ./spec/dump_methods_spec.rb:93 # SeedDump.dump with a batch_size parameter should not raise an exception
rspec ./spec/dump_methods_spec.rb:97 # SeedDump.dump with a batch_size parameter should not cause records to not be dumped
rspec ./spec/dump_methods_spec.rb:105 # SeedDump.dump Array should return the dump of the models passed in
rspec ./spec/dump_methods_spec.rb:26 # SeedDump.dump without file option should return the dump of the models passed in
rspec ./spec/dump_methods_spec.rb:62 # SeedDump.dump ActiveRecord relation with an order parameter should dump the models in the specified order
rspec ./spec/dump_methods_spec.rb:77 # SeedDump.dump ActiveRecord relation with a limit parameter should dump the number of models specified by the limit when the limit is smaller than the batch size
rspec ./spec/dump_methods_spec.rb:83 # SeedDump.dump ActiveRecord relation with a limit parameter should dump the number of models specified by the limit when the limit is larger than the batch size but not a multiple of the batch size
rspec ./spec/dump_methods_spec.rb:71 # SeedDump.dump ActiveRecord relation without an order parameter should dump the models sorted by primary key ascending
rspec ./spec/dump_methods_spec.rb:123 # SeedDump.dump Range should dump a class with ranges
rspec ./spec/dump_methods_spec.rb:115 # SeedDump.dump with an exclude parameter should exclude the specified attributes from the dump
rspec ./spec/dump_methods_spec.rb:40 # SeedDump.dump with file option should dump the models to the specified file
rspec ./spec/dump_methods_spec.rb:47 # SeedDump.dump with file option with append option should append to the file rather than overwriting it
