### PR TITLE
fix: rspec config deprecation warning.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,6 @@ ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':me
 FactoryGirl.find_definitions
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-
   config.order = 'random'
 
   config.include Helpers


### PR DESCRIPTION
RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= is deprecated, it is now set to true as default and setting it to false has no effect.
