### PR TITLE
Exclude models

### DIFF
--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -20,6 +20,17 @@ class SeedDump
 
       append = (env['APPEND'] == 'true')
 
+      all_except_env = env['ALL_EXCEPT']
+      excluded_models = if all_except_env
+                           all_except_env.split(',')
+                                        .collect {|x| x.strip.underscore.singularize.camelize.constantize }
+                        end
+      if excluded_models
+        excluded_models.each do |exclude|
+          models.delete(exclude)
+        end
+      end
+
       models.each do |model|
         model = model.limit(env['LIMIT'].to_i) if env['LIMIT']
 
@@ -35,4 +46,3 @@ class SeedDump
     end
   end
 end
-

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -111,6 +111,16 @@ describe SeedDump do
       end
     end
 
+    describe "ALL_EXCEPT" do
+        it "should dump all non-empty models except the specified models" do
+          FactoryGirl.create(:another_sample)
+
+          SeedDump.should_receive(:dump).with(Sample, anything)
+
+          SeedDump.dump_using_environment('ALL_EXCEPT' => 'AnotherSample')
+        end
+      end
+
     it 'should run ok without ActiveRecord::SchemaMigration being set (needed for Rails Engines)' do
       schema_migration = ActiveRecord::SchemaMigration
 


### PR DESCRIPTION
Added an EXCLUDE option to exclude one or many models from the dump. Response to  #77. Spec is provided in the second commit.