### PR TITLE
Dump HABTM tables in only one direction

### DIFF
--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -27,6 +27,15 @@ class SeedDump
                           .each { |exclude| models.delete(exclude) }
       end
 
+
+      # Eliminate HABTM models that have the same underlying table; otherwise 
+      # they'll be dumped twice, once in each direction. Probably should apply
+      # to all models, but it's possible there are edge cases in which this 
+      # is not the right behavior.
+
+      habtm, non_habtm = models.partition {|m| m.name =~ /^HABTM_/}
+      models = non_habtm + habtm.uniq { |m| m.table_name }
+
       models.each do |model|
         model = model.limit(env['LIMIT'].to_i) if env['LIMIT']
 


### PR DESCRIPTION
Currently, association tables used with has_and_belongs_to_many map to two different models, and since seed_dump doesn't treat these specially, they end up being dumped twice. This patch prunes the to-dump set of models so that no more than one HABTM model refers to each table.