### PR TITLE
Topologically sort models to be dumped

### DIFF
--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -1,3 +1,5 @@
+require 'tsort'
+
 class SeedDump
   module Environment
 
@@ -27,6 +29,27 @@ class SeedDump
                           .each { |exclude| models.delete(exclude) }
       end
 
+      # Sort models in dependency order to accommodate foreign key checks or validations.
+      # Based on code by Ryan Stenberg
+      # https://www.viget.com/articles/identifying-foreign-key-dependencies-from-activerecordbase-classes
+
+      dependencies = models.map do |model|
+        associations = model.reflect_on_all_associations(:belongs_to)
+        referents = associations.map do |association|
+          if association.options[:polymorphic]
+            ActiveRecord::Base.descendants.select do |other_model|
+              other_model.reflect_on_all_associations(:has_many).any? do |has_many_association|
+                has_many_association.options[:as] == association.name
+              end
+            end
+          else
+            association.klass
+          end
+        end
+        [ model, referents.flatten ]
+      end
+      models = TSortableHash[*dependencies.flatten(1)].tsort
+
       models.each do |model|
         model = model.limit(env['LIMIT'].to_i) if env['LIMIT']
 
@@ -40,5 +63,15 @@ class SeedDump
         append = true
       end
     end
+
+    class TSortableHash < Hash
+      include TSort
+      alias tsort_each_node each_key
+      def tsort_each_child(node, &block)
+        fetch(node).each(&block)
+      end
+    end      
+
   end
 end
+


### PR DESCRIPTION
This patch sorts models in dependency order before dumping. This makes seed_dump work correctly with foreign keys and dependencies, including indirect relationships through join tables. (Typically, you must include the :id fields to recreate relationships, of course.) See the original blog post by Ryan Stenberg for a detailed explanation of the logic.

There are currently no tests included, but I will add some if you are interested in integrating this patch.