### PR TITLE
Fixes Issue #84, BigDecimal being dumped funky

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -36,7 +36,9 @@ class SeedDump
 
     def value_to_s(value)
       value = case value
-              when BigDecimal, IPAddr
+              when BigDecimal
+                value.to_f
+              when IPAddr
                 value.to_s
               when Date, Time, DateTime
                 value.to_s(:db)


### PR DESCRIPTION
Big Decimals were being dumped with to_s which led to the output file showing them as `#<BigDecimal:7fc7c9662090,'0.25E2',9(18)>`

Fixed by changing the `value_to_s` method to call value.to_f when BigDecimal instead of calling value.to_s