### PR TITLE
Fixes Issue #84, BigDecimal being dumped funky When in Hash

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -36,7 +36,9 @@ class SeedDump
 
     def value_to_s(value)
       value = case value
-              when BigDecimal, IPAddr
+              when BigDecimal
+                value.to_f
+              when IPAddr
                 value.to_s
               when Date, Time, DateTime
                 value.to_s(:db)

--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -44,6 +44,8 @@ class SeedDump
                 value.to_s(:db)
               when Range
                 range_to_string(value)
+              when Hash
+                hash_to_string(value)
               else
                 value
               end
@@ -55,6 +57,36 @@ class SeedDump
       from = object.begin.respond_to?(:infinite?) && object.begin.infinite? ? '' : object.begin
       to   = object.end.respond_to?(:infinite?) && object.end.infinite? ? '' : object.end
       "[#{from},#{to}#{object.exclude_end? ? ')' : ']'}"
+    end
+
+    def hash_to_string(object)
+      object.each do |key, value|
+        case value
+        when Hash
+          hash_to_string(value)
+        when Array
+          array_to_string(value)
+        else
+          corrected_value = value_to_s(value)
+          object[key] = corrected_value
+        end
+      end
+      return object
+    end
+
+    def array_to_string(object)
+      object.each_index do |index|
+        value = object[index]
+        case value
+        when Hash
+          hash_to_string(value)
+        when Array
+          array_to_string(value)
+        else
+          object[index] = value_to_s(value)
+        end
+      end
+      return object
     end
 
     def open_io(options)


### PR DESCRIPTION
When storing serialized hashes in the DB, values in the hash may not be printed correctly in the output file when they are BigDecimal. Added method to recursively convert all values in hashes to strings to correct this.
