### PR TITLE
Provide RGeo support

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -42,7 +42,7 @@ class SeedDump
                 value.to_s(:db)
               when Range
                 range_to_string(value)
-              when ->(v) { v.class.ancestors.include?(RGeo::Feature::Instance) }
+              when ->(v) { v.class.ancestors.map(&:to_s).include?('RGeo::Feature::Instance') }
                 value.to_s
               else
                 value

--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -42,6 +42,8 @@ class SeedDump
                 value.to_s(:db)
               when Range
                 range_to_string(value)
+              when ->(v) { v.class.ancestors.include?(RGeo::Feature::Instance) }
+                value.to_s
               else
                 value
               end


### PR DESCRIPTION
Correctly dump the value of a RGeo attribute by checking its ancestors line:

```
    def value_to_s(value)
      value = case value
              when BigDecimal, IPAddr
                value.to_s
              when Date, Time, DateTime
                value.to_s(:db)
              when Range
                range_to_string(value)
              when ->(v) { v.class.ancestors.map(&:to_s).include?('RGeo::Feature::Instance') }
                value.to_s
              else
                value
              end

      value.inspect
    end
```

I tested it and it works for my geom columns with postgis, rgeo and activerecord-postgis-adapter. I made sure not to break any spec with my 2nd commit. 

Thanks for your review ! 