### PR TITLE
Add includes options to be able add extra fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Options are common to both the Rake task and the console, except where noted.
 
 `exclude`: Attributes to be excluded from the dump. Pass a comma-separated list to the Rake task (i.e. `name,age`) and an array on the console (i.e. `[:name, :age]`). Default: `[:id, :created_at, :updated_at]`.
 
+`includes`: A hash of key values you want to include as attribute of the dump (i.e. `{ password: 123, password_confirmation: 123 }`). Useful when you need to populate a virtual value like password of Devise. Default: `{}`.
+
 `file`: Write to the specified output file. The Rake task default is `db/seeds.rb`. The console returns the dump as a string by default.
 
 `import`: If `true`, output will be in the format needed by the [activerecord-import](https://github.com/zdennis/activerecord-import) gem, rather than the default format. Default: `false`.

--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -25,6 +25,10 @@ class SeedDump
         attribute_strings << dump_attribute_new(attribute, value, options) unless options[:exclude].include?(attribute.to_sym)
       end
 
+      options[:includes].each do |attribute, value|
+        attribute_strings << dump_attribute_new(attribute, value, options)
+      end if options[:includes].present?
+
       open_character, close_character = options[:import] ? ['[', ']'] : ['{', '}']
 
       "#{open_character}#{attribute_strings.join(", ")}#{close_character}"

--- a/spec/dump_methods_spec.rb
+++ b/spec/dump_methods_spec.rb
@@ -113,6 +113,15 @@ describe SeedDump do
 
     context 'with an exclude parameter' do
       it 'should exclude the specified attributes from the dump' do
+        expected_output = %(Sample.create!([\n  {string: "string", text: "text", integer: 42, float: 3.14, decimal: "2.72", datetime: "1776-07-04 19:14:00", time: "2000-01-01 03:15:00", date: "1863-11-19", binary: "binary", boolean: false, key_1: "value_1", key_2: "value_2"}\n])\n)
+        includes        = { key_1: "value_1", key_2: "value_2" }
+
+        expect(SeedDump.dump(Sample.limit(1), includes: includes)).to eq expected_output
+      end
+    end
+
+    context 'when includes options is given' do
+      it 'includes the key value provided' do
         expected_output = "Sample.create!([\n  {text: \"text\", integer: 42, decimal: \"2.72\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false},\n  {text: \"text\", integer: 42, decimal: \"2.72\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false},\n  {text: \"text\", integer: 42, decimal: \"2.72\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false}\n])\n"
 
         SeedDump.dump(Sample, exclude: [:id, :created_at, :updated_at, :string, :float, :datetime]).should eq(expected_output)


### PR DESCRIPTION
I'm using Devise and I need to insert the model `User` with a given `password` and `password_confirmation`, since it is not dumped from `record.attributes`.

With this options I can add extra fields like that one.