### PR TITLE
Attributes not dumping

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -21,7 +21,7 @@ class SeedDump
       # We select only string attribute names to avoid conflict
       # with the composite_primary_keys gem (it returns composite
       # primary key attribute names as hashes).
-      record.attributes.select {|key| key.is_a?(String) }.each do |attribute, value|
+      record.attributes.select {|key| key.is_a?(String) || key.is_a?(Symbol) }.each do |attribute, value|
         attribute_strings << dump_attribute_new(attribute, value, options) unless options[:exclude].include?(attribute.to_sym)
       end
 


### PR DESCRIPTION
Changing the attribute check to also accept a symbol. Without this, only random tables were being exported, this change allows all tables to export.


See https://github.com/rroblak/seed_dump/issues/132
Mine was only dumping 3 tables.