### PR TITLE
fix broken spec.

### DIFF
--- a/spec/dump_methods_spec.rb
+++ b/spec/dump_methods_spec.rb
@@ -30,7 +30,7 @@ describe SeedDump do
 
     context 'with file option' do
       before do
-        @filename = Tempfile.new(File.join(Dir.tmpdir, 'foo'), nil)
+        @filename = Tempfile.new('foo', nil)
       end
 
       after do


### PR DESCRIPTION
Was embedding tmpdir (a randomly generated folder on some machines) twice, which then didn't exist: 

```
  1) SeedDump.dump with file option should dump the models to the specified file
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: @filename = Tempfile.new(File.join(Dir.tmpdir, 'foo'), nil)
          
          Errno::ENOENT:
            No such file or directory @ rb_sysopen - /var/folders/yh/RANDOMNESS/T/var/folders/yh/RANDOMNESS/T/foo20180522-6029-7061cr
          # ./spec/dump_methods_spec.rb:33:in `new'
          # ./spec/dump_methods_spec.rb:33:in `block (4 levels) in <top (required)>'

     1.2) Failure/Error: File.unlink(@filename)
          
          TypeError:
            no implicit conversion of nil into String
          # ./spec/dump_methods_spec.rb:37:in `unlink'
          # ./spec/dump_methods_spec.rb:37:in `block (4 levels) in <top (required)>'
```