### PR TITLE
Add option for `after_each_batch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Options are common to both the Rake task and the console, except where noted.
 `model[s]`: Restrict the dump to the specified comma-separated list of models. Default: all models. If you are using a Rails engine you can dump a specific model by passing "EngineName::ModelName". Rake task only. Example: `rake db:seed:dump MODELS="User, Position, Function"`
 
 `models_exclude`: Exclude the specified comma-separated list of models from the dump. Default: no models excluded. Rake task only. Example: `rake db:seed:dump MODELS_EXCLUDE="User"`
+
+`after_each_batch`: Accepts a lambda that is called after each batch of records is processed.

--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -86,6 +86,8 @@ class SeedDump
       send(enumeration_method, records, io, options) do |record_strings, last_batch|
         io.write(record_strings.join(",\n  "))
 
+        options[:after_each_batch].call if options.include? :after_each_batch
+
         io.write(",\n  ") unless last_batch
       end
 


### PR DESCRIPTION
This `after_each_batch` option solved a particular problem where I would be dumping rows and would consistently run out of memory even with smaller batch sizes. Manually calling garbage collect seemed to do the trick.

This new option allows users to pass in something like this.

```ruby
options = {
  file:             './path/to/my/seed.rb',
  append:           true,
  import:           { validate: false },
  exclude:          [],
  batch_size:       100,
  after_each_batch: -> { started_at = Time.now; GC.start; puts { "GC took #{Time.now - started_at}" } }
}
SeedDump.dump(MyAwesomeModel, options)
```

 Thoughts? Would like to see this merged in so I can switch back to the original version. Thanks for the awesome gem btw. This has saved me so much trouble =)