### PR TITLE
Allow passing custom methods

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -70,8 +70,7 @@ class SeedDump
     def write_records_to_io(records, io, options)
       options[:exclude] ||= [:id, :created_at, :updated_at]
 
-      method = options[:import] ? 'import' : 'create!'
-      io.write("#{model_for(records)}.#{method}(")
+      io.write("#{model_for(records)}.#{method_name(options)}(")
       if options[:import]
         io.write("[#{attribute_names(records, options).map {|name| name.to_sym.inspect}.join(', ')}], ")
       end
@@ -125,5 +124,14 @@ class SeedDump
       end
     end
 
+    private
+
+    def method_name(options)
+      import, method = options.values_at(:import, :method)
+      return :import if import
+      return method if method
+
+      :create!
+    end
   end
 end

--- a/spec/dump_methods_spec.rb
+++ b/spec/dump_methods_spec.rb
@@ -127,6 +127,13 @@ describe SeedDump do
       end
     end
 
+    context 'passing a custom method' do
+      it 'should find_or_create_by when given the method name' do
+        expected_output = "Sample.find_or_create_by([\n  {string: \"string\", text: \"text\", integer: 42, float: 3.14, decimal: \"2.72\", datetime: \"1776-07-04 19:14:00\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false},\n  {string: \"string\", text: \"text\", integer: 42, float: 3.14, decimal: \"2.72\", datetime: \"1776-07-04 19:14:00\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false},\n  {string: \"string\", text: \"text\", integer: 42, float: 3.14, decimal: \"2.72\", datetime: \"1776-07-04 19:14:00\", time: \"2000-01-01 03:15:00\", date: \"1863-11-19\", binary: \"binary\", boolean: false}\n])\n"
+        SeedDump.dump(Sample, method: :find_or_create_by).should eq(expected_output)
+      end
+    end
+
     context 'activerecord-import' do
       it 'should dump in the activerecord-import format when import is true' do
         SeedDump.dump(Sample, import: true, exclude: []).should eq <<-RUBY


### PR DESCRIPTION
Allows passing custom method name that can be interpolated for creating the dump, e.g `find_or_create_by`:
```ruby
Movie.all
# [#<Movie:0x00007f89f799f9e8 id: 1, name: "Machuca", status: nil, created_at: Sat, 06 Jun 2020 20:45:27 UTC +00:00, updated_at: Sat, 06 Jun 2020 20:45:27 UTC +00:00>,
   #<Movie:0x00007f89f799f920 id: 2, name: "Burned after reading", status: nil, created_at: Sat, 06 Jun 2020 20:45:39 UTC +00:00, updated_at: Sat, 06 Jun 2020 20:45:39 UTC +00:00>]

SeedDump.dump(Movie, method: :find_or_create_by)
   (0.4ms)  SELECT COUNT(*) FROM "movies"
   (0.3ms)  SELECT COUNT(*) FROM "movies"
  Movie Load (0.3ms)  SELECT "movies".* FROM "movies" LIMIT $1 OFFSET $2  [["LIMIT", 2], ["OFFSET", 0]]
# "Movie.find_or_create_by([\n  {name: \"Machuca\", status: nil},\n  {name: \"Burned after reading\", status: nil}\n])\n"
```

or `find_or_create_by!` or `create_or_find_by` or whatever you want.