### PR TITLE
Strict model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Options are common to both the Rake task and the console, except where noted.
 `model[s]`: Restrict the dump to the specified comma-separated list of models. Default: all models. If you are using a Rails engine you can dump a specific model by passing "EngineName::ModelName". Rake task only. Example: `rake db:seed:dump MODELS="User, Position, Function"`
 
 `models_exclude`: Exclude the specified comma-separated list of models from the dump. Default: no models excluded. Rake task only. Example: `rake db:seed:dump MODELS_EXCLUDE="User"`
+
+`strict_model_name`: Do not singularize any of the model names passed in the "MODEL[S]" option. If you need to dump only a model named `Users` you can. Example: `rake db:seed:dump STRICT_MODEL_NAME=true MODEL="Users"`

--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -78,6 +78,18 @@ class SeedDump
                         end
     end
 
+    # Internal: Retrieves an Array of Class constants parsed from the argument
+    # "model_names_env", and `nil` if the argument is nil
+    def parse_model_names(strict_model_name, model_names_env)
+      model_names = model_names_env.to_s.split(',')
+
+      if strict_model_name
+        model_names.collect {|x| x.strip.underscore.camelize.constantize }
+      else
+        model_names.collect {|x| x.strip.underscore.singularize.camelize.constantize }
+      end
+    end
+
     # Internal: Returns a Boolean indicating whether the value for the "APPEND"
     # key in the given Hash is equal to the String "true" (ignoring case),
     # false if no value exists.

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -133,6 +133,38 @@ describe SeedDump do
       end
     end
 
+    describe "STRICT_MODEL_NAME" do
+      context "if STRICT_MODEL_NAME is specified without MODEL or MODELS env" do
+        it "should dump all non-empty models" do
+          FactoryBot.create(:another_sample)
+
+          [Sample, AnotherSample].each do |model|
+            SeedDump.should_receive(:dump).with(model, anything)
+          end
+
+          SeedDump.dump_using_environment('STRICT_MODEL_NAME' => 'true')
+        end
+      end
+
+      context "if STRICT_MODEL_NAME is specified with MODEL or MODELS env" do
+        context "when STRICT_MODEL_NAME is true" do
+          it "should not singularize and raise a NameError" do
+            expect do
+              SeedDump.dump_using_environment('MODELS' => 'samples', 'STRICT_MODEL_NAME' => 'true')
+            end.to raise_error NameError
+          end
+        end
+
+        context "when STRICT_MODEL_NAME is false" do
+          it "should singularize the models and dump them" do
+            SeedDump.should_receive(:dump).with(Sample, anything)
+
+            SeedDump.dump_using_environment('MODELS' => 'samples', 'STRICT_MODEL_NAME' => 'false')
+          end
+        end
+      end
+    end
+
     it 'should run ok without ActiveRecord::SchemaMigration being set (needed for Rails Engines)' do
       schema_migration = ActiveRecord::SchemaMigration
 

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -108,6 +108,12 @@ describe SeedDump do
             SeedDump.dump_using_environment(model_env => 'Sample')
           end
 
+          it "should singularize the models and dump them" do
+            SeedDump.should_receive(:dump).with(Sample, anything)
+
+            SeedDump.dump_using_environment(model_env => 'samples')
+          end
+
           it "should not dump empty models" do
             SeedDump.should_not_receive(:dump).with(EmptyModel, anything)
 

--- a/spec/factories/another_samples.rb
+++ b/spec/factories/another_samples.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :another_sample do
-    string   'string'
-    text     'text'
-    integer  42
-    float    3.14
-    decimal  2.72
-    datetime DateTime.parse('July 4, 1776 7:14pm UTC')
-    time     Time.parse('3:15am UTC')
-    date     Date.parse('November 19, 1863')
-    binary   'binary'
-    boolean  false
+    string   { 'string' }
+    text     { 'text' }
+    integer  { 42 }
+    float    { 3.14 }
+    decimal  { 2.72 }
+    datetime { DateTime.parse('July 4, 1776 7:14pm UTC') }
+    time     { Time.parse('3:15am UTC') }
+    date     { Date.parse('November 19, 1863') }
+    binary   { 'binary' }
+    boolean  { false }
   end
 end

--- a/spec/factories/samples.rb
+++ b/spec/factories/samples.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
   factory :sample do
-    string   'string'
-    text     'text'
-    integer  42
-    float    3.14
-    decimal  2.72
-    datetime DateTime.parse('July 4, 1776 7:14pm UTC')
-    time     Time.parse('3:15am UTC')
-    date     Date.parse('November 19, 1863')
-    binary   'binary'
-    boolean  false
-    created_at DateTime.parse('July 20, 1969 20:18 UTC')
-    updated_at DateTime.parse('November 10, 1989 4:20 UTC')
+    string   { 'string' }
+    text     { 'text' }
+    integer  { 42 }
+    float    { 3.14 }
+    decimal  { 2.72 }
+    datetime { DateTime.parse('July 4, 1776 7:14pm UTC') }
+    time     { Time.parse('3:15am UTC') }
+    date     { Date.parse('November 19, 1863') }
+    binary   { 'binary' }
+    boolean  { false }
+    created_at { DateTime.parse('July 20, 1969 20:18 UTC') }
+    updated_at { DateTime.parse('November 10, 1989 4:20 UTC') }
   end
 end

--- a/spec/factories/yet_another_samples.rb
+++ b/spec/factories/yet_another_samples.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :yet_another_sample do
-    string   'string'
-    text     'text'
-    integer  42
-    float    3.14
-    decimal  2.72
-    datetime DateTime.parse('July 4, 1776 7:14pm UTC')
-    time     Time.parse('3:15am UTC')
-    date     Date.parse('November 19, 1863')
-    binary   'binary'
-    boolean  false
+    string   { 'string' }
+    text     { 'text' }
+    integer  { 42 }
+    float    { 3.14 }
+    decimal  { 2.72 }
+    datetime { DateTime.parse('July 4, 1776 7:14pm UTC') }
+    time     { Time.parse('3:15am UTC') }
+    date     { Date.parse('November 19, 1863') }
+    binary   { 'binary' }
+    boolean  { false }
   end
 end


### PR DESCRIPTION
What
Currently Seed.dump will singularize all model names given in the MODELS 'option'. Here I propose to have the option to not singularize.

Why
For cases where model names so not follow the convention of having the model names as singular nouns. 

How
Following the logic in place to send arguments in the rake task and creating a branch to not singularize the model names.
Since there is 2 ways to pass in model names (MODELS and EXCLUDE_MODELS), I also perform a tiny refactor in order to have this new option crossing the already existing options.

Let me know what you think I probably cross the line with the amount of changes in this PR. We can split it or discard some changes.
Cheers