### PR TITLE
Use `to_fs(:db)` vs deprecated `to_s(:db)`

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -39,7 +39,7 @@ class SeedDump
               when BigDecimal, IPAddr
                 value.to_s
               when Date, Time, DateTime
-                value.to_s(:db)
+                value.respond_to?(:to_fs) ? value.to_fs(:db) : value.to_s(:db)
               when Range
                 range_to_string(value)
               when ->(v) { v.class.ancestors.map(&:to_s).include?('RGeo::Feature::Instance') }


### PR DESCRIPTION
`to_s(:db)` is deprecated in recent Rails versions (e.g. 7.0.4). This causes the dump to break on dates. 