### PR TITLE
changes depreciated .to_s to .to_formatted_s for a SeedDump gemfile

### DIFF
--- a/lib/seed_dump/dump_methods.rb
+++ b/lib/seed_dump/dump_methods.rb
@@ -39,7 +39,7 @@ class SeedDump
               when BigDecimal, IPAddr
                 value.to_s
               when Date, Time, DateTime
-                value.to_s(:db)
+                value.to_formatted_s(:db)
               when Range
                 range_to_string(value)
               when ->(v) { v.class.ancestors.map(&:to_s).include?('RGeo::Feature::Instance') }


### PR DESCRIPTION
.to_s is depreciated
changing to .to_formatted_s