### PR TITLE
Fix IMPORT env var when passing JSON options

### DIFF
--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -258,11 +258,26 @@ class SeedDump
       parse_boolean_value(env['APPEND'])
     end
 
-    # Internal: Returns a Boolean indicating whether the value for the "IMPORT"
-    # key in the given Hash is equal to the String "true" (ignoring case),
-    # false if  no value exists.
+    # Internal: Returns true if the IMPORT env var enables bulk import.
+    #
+    # IMPORT may be:
+    # - "true" (case-insensitive)
+    # - A JSON hash of activerecord-import options (e.g. '{ "validate": false }')
+    #
+    # Returns false if IMPORT is unset or invalid.
     def retrieve_import_value(env)
-      parse_boolean_value(env['IMPORT'])
+      value = env['IMPORT']
+      return false if value.nil?
+
+      # Backward compatibility: IMPORT=true
+      return true if parse_boolean_value(value)
+
+      # New behavior: IMPORT is a JSON hash of options
+      begin
+        JSON.parse(value)
+      rescue JSON::ParserError
+        false
+      end
     end
 
     # Internal: Returns a Boolean indicating whether the value for the "INSERT_ALL"

--- a/spec/environment_spec.rb
+++ b/spec/environment_spec.rb
@@ -41,6 +41,33 @@ describe SeedDump do
       end
     end
 
+    describe 'IMPORT' do
+      it "should specify import as true if the IMPORT env var is 'true'" do
+        expect(SeedDump).to receive(:dump).with(anything, include(import: true))
+        SeedDump.dump_using_environment('IMPORT' => 'true')
+      end
+
+      it "should specify import as true if the IMPORT env var is 'TRUE'" do
+        expect(SeedDump).to receive(:dump).with(anything, include(import: true))
+        SeedDump.dump_using_environment('IMPORT' => 'TRUE')
+      end
+
+      it "should specify import as Hash if the IMPORT env var is a JSON hash" do
+        expect(SeedDump).to receive(:dump).with(anything, include(import: {'validate' => false}))
+        SeedDump.dump_using_environment('IMPORT' => '{ "validate": false }')
+      end
+
+      it "should specify import as false if the IMPORT env var is invalid JSON" do
+        expect(SeedDump).to receive(:dump).with(anything, include(import: false))
+        SeedDump.dump_using_environment('IMPORT' => '{ validate: false ')
+      end
+
+      it "should specify import as false if the IMPORT env var is not set" do
+        expect(SeedDump).to receive(:dump).with(anything, include(import: false))
+        SeedDump.dump_using_environment
+      end
+    end
+
     describe 'BATCH_SIZE' do
       it 'should pass along the specified batch size' do
         expect(SeedDump).to receive(:dump).with(anything, include(batch_size: 17))


### PR DESCRIPTION
### Summary

`IMPORT` is documented as supporting activerecord-import options (e.g. `IMPORT='{ "validate": false }'`), but this currently does not work.

The existing implementation only treats the literal string `"true"` (case-insensitive) as enabling import. As a result, JSON hash values always evaluate to `false`, and `create!` is used instead of `import`.

This PR fixes that behavior and adds test coverage.

---

### What changed

- `IMPORT` now evaluates to `true` when:
  - It is set to `"true"` (case-insensitive), **or**
  - It contains a valid JSON hash (used for import options)
- Invalid or unset `IMPORT` values still evaluate to `false`
- Added specs covering:
  - Boolean `IMPORT=true`
  - JSON hash values (e.g. `{ "validate": false }`)
  - Invalid JSON input

---

### Related

- Original discussion: #140
